### PR TITLE
Remove __implements__ usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylint_super_not_called"
-version = "0.9.1"
+version = "0.10.0"
 authors = [
   { name="Nicolas Mussat", email="nicolas@prose.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "A Pylint plugin to ensure overloaded methods are calling the parent method with super"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/src/super_not_called.py
+++ b/src/super_not_called.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 import astroid
 from astroid import bases, nodes
 from pylint.checkers import BaseChecker, utils
-from pylint.interfaces import IAstroidChecker
 from pylint.checkers.utils import decorated_with, is_builtin_object, node_frame_class
 from pylint.interfaces import INFERENCE
 
@@ -35,8 +34,6 @@ def _ancestors_to_call(klass_node: nodes.ClassDef, method='__init__') -> dict[no
 
 
 class SuperNotCalledChecker(BaseChecker):
-
-    __implements__ = IAstroidChecker
 
     name = 'super-not-called'
     priority = -1


### PR DESCRIPTION
Pylint removed support for this in this PR https://github.com/pylint-dev/pylint/pull/8404

Fixes the following error:
```
Traceback (most recent call last):
  File "/usr/src/app/.venv/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
  File "/usr/src/app/.venv/lib/python3.10/site-packages/pylint/__init__.py", line 34, in run_pylint
    PylintRun(argv or sys.argv[1:])
  File "/usr/src/app/.venv/lib/python3.10/site-packages/pylint/lint/run.py", line 162, in __init__
    args = _config_initialization(
  File "/usr/src/app/.venv/lib/python3.10/site-packages/pylint/config/config_initialization.py", line 61, in _config_initialization
    linter.load_plugin_modules(utils._splitstrip(config_data["load-plugins"]))
  File "/usr/src/app/.venv/lib/python3.10/site-packages/pylint/lint/pylinter.py", line 380, in load_plugin_modules
    module = astroid.modutils.load_module_from_name(modname)
  File "/usr/src/app/.venv/lib/python3.10/site-packages/astroid/modutils.py", line 194, in load_module_from_name
    module = importlib.import_module(dotted_name)
  File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/src/app/.venv/lib/python3.10/site-packages/pylint_super_not_called/__init__.py", line 6, in <module>
    from pylint.interfaces import IAstroidChecker
ImportError: cannot import name 'IAstroidChecker' from 'pylint.interfaces' (/usr/src/app/.venv/lib/python3.10/site-packages/pylint/interfaces.py)
``` 